### PR TITLE
feat(length): Add readonly length prop to channel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export type Channel<T> = {
   [putters]: (() => void)[];
   [takers]: ((msg: T) => void)[];
   [racers]: ((ch: Channel<T>) => void)[];
+  readonly length: number;
   [Symbol.asyncIterator]: (() => AsyncIterableIterator<T>);
 }
 
@@ -57,17 +58,19 @@ function forEach<T>(sel: Selectable<T>, fn: (c: Channel<T>) => void): void {
 /* public methods */
 
 function channel<T>(): Channel<T> {
-  return {
+  const chan: Channel<T> = {
     [messages]: [],
     [putters]: [],
     [takers]: [],
     [racers]: [],
+    get length() { return chan[messages].length; },
     async *[Symbol.asyncIterator]() {
       while (true) {
         yield await _take(this);
       }
     }
   };
+  return chan;
 }
 
 function put<T>(ch: Channel<T>, msg: T): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,19 +58,18 @@ function forEach<T>(sel: Selectable<T>, fn: (c: Channel<T>) => void): void {
 /* public methods */
 
 function channel<T>(): Channel<T> {
-  const chan: Channel<T> = {
+  return {
     [messages]: [],
     [putters]: [],
     [takers]: [],
     [racers]: [],
-    get length() { return chan[messages].length; },
+    get length() { return this[messages].length; },
     async *[Symbol.asyncIterator]() {
       while (true) {
         yield await _take(this);
       }
     }
   };
-  return chan;
 }
 
 function put<T>(ch: Channel<T>, msg: T): Promise<void> {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -31,7 +31,7 @@ test('[csp] take', t => {
 
 test('[csp] length', t => {
   const chan = channel<string>();
-  t.equals(chan.length, 0, 'should start with length 1');
+  t.equals(chan.length, 0, 'should start with length 0');
   put(chan, 'foo');
   put(chan, 'bar');
   t.equals(chan.length, 2, 'should equal the message queue size');

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -139,7 +139,7 @@ test('[csp] select Map, chan1 ready', async t => {
   const m = msg();
   const key1 = Symbol();
   const key2 = Symbol();
-  const result = select<Input>(new Map<Symbol, Channel<Input>>([ [ key1, chan1 ], [ key2, chan2 ] ]));
+  const result = select<Input>(new Map<symbol, Channel<Input>>([ [ key1, chan1 ], [ key2, chan2 ] ]));
   await put(chan1, m);
   const [ id, res ] = await result;
   t.equal(id, key1, 'should receive the correct id');

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -11,7 +11,7 @@ const msg = (() => {
 test('[csp] channel', t => {
   const chan = channel<number>();
   t.equal(Object.getOwnPropertySymbols(chan).length, 5, 'should contain 5 symbol properties');
-  t.equal(Object.keys(chan).length, 0, 'should not expose properties normally');
+  t.equal(Object.keys(chan).length, 1, 'should only expose length propery');
   t.end();
 });
 
@@ -26,6 +26,24 @@ test('[csp] take', t => {
   const chan = channel();
   const res = take(chan);
   t.ok(res instanceof Promise, 'should return an instance of a Promise');
+  t.end();
+});
+
+test('[csp] length', t => {
+  const chan = channel<string>();
+  t.equals(chan.length, 0, 'should start with length 1');
+  put(chan, 'foo');
+  put(chan, 'bar');
+  t.equals(chan.length, 2, 'should equal the message queue size');
+  take(chan);
+  t.equals(chan.length, 1, 'should equal the message queue size');
+  t.end();
+});
+
+test('[csp] length, readonly', t => {
+  const chan = channel<string>();
+  (chan as any).length = 9;
+  t.equals(chan.length, 0, 'should be unchanged');
   t.end();
 });
 


### PR DESCRIPTION
The channel does not yet have any introspection methods, so this length property allows checking the number of messages currently waiting in the queue.

Also, fixed a minor, unrelated lint error in the spec.